### PR TITLE
Pass terminal width to Report instance

### DIFF
--- a/bin/sql_tracker
+++ b/bin/sql_tracker
@@ -1,9 +1,11 @@
 #!/usr/bin/env ruby
+require 'sql_tracker/terminal'
 require 'sql_tracker/report'
 require 'json'
 require 'optparse'
 
 options = {}
+default_options = { sort_by: 'count', terminal_width: SqlTracker::Terminal.width }
 
 parser = OptionParser.new(ARGV) do |o|
   o.banner = 'Usage: sql_tracker [file.json]+ [--sort-by=COLUMN]'
@@ -11,12 +13,17 @@ parser = OptionParser.new(ARGV) do |o|
   o.on('-s', '--sort-by COLUMN', 'The name of column that is used for sorting the table. Options: count, duration') do |arg|
     options[:sort_by] = arg if %(count duration).include?(arg)
   end
+
+  o.on('-w', '--terminal-width WIDTH', Integer,
+       "The width of the printed report. " \
+       "Default: #{default_options[:terminal_width]}. " \
+       "Minimum #{SqlTracker::Terminal::MIN_WIDTH}") do |arg|
+    options[:terminal_width] = arg if arg >= SqlTracker::Terminal::MIN_WIDTH
+  end
 end
 
 parser.parse!
 parser.abort(parser.help) if ARGV.empty?
-
-default_options = { sort_by: 'count' }
 
 options = default_options.merge(options)
 

--- a/lib/sql_tracker/report.rb
+++ b/lib/sql_tracker/report.rb
@@ -1,6 +1,7 @@
 module SqlTracker
   class Report
     attr_accessor :raw_data
+    attr_accessor :terminal_width
 
     def initialize(data)
       self.raw_data = data
@@ -26,6 +27,7 @@ module SqlTracker
     end
 
     def print_text(options)
+      self.terminal_width = options.fetch(:terminal_width)
       f = STDOUT
       f.puts '=================================='
       f.puts "Total Unique SQL Queries: #{data.keys.size}"
@@ -124,30 +126,6 @@ module SqlTracker
 
     def duration_width
       15
-    end
-
-    def terminal_width
-      @terminal_width ||= begin
-        result = unix? ? dynamic_width : 80
-        result < 10 ? 80 : result
-      end
-    end
-
-    def dynamic_width
-      @dynamic_width ||= (dynamic_width_stty.nonzero? || dynamic_width_tput)
-    end
-
-    def dynamic_width_stty
-      `stty size 2>/dev/null`.split[1].to_i
-    end
-
-    def dynamic_width_tput
-      `tput cols 2>/dev/null`.to_i
-    end
-
-    def unix?
-      RUBY_PLATFORM =~
-        /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
     end
   end
 end

--- a/lib/sql_tracker/terminal.rb
+++ b/lib/sql_tracker/terminal.rb
@@ -1,0 +1,28 @@
+module SqlTracker
+  class Terminal
+    DEFAULT_WIDTH = 80
+    MIN_WIDTH = 10
+
+    def self.width
+      if unix?
+        result = (dynamic_width_stty.nonzero? || dynamic_width_tput)
+        result < MIN_WIDTH ? DEFAULT_WIDTH : result
+      else
+        DEFAULT_WIDTH
+      end
+    end
+
+    def self.dynamic_width_stty
+      `stty size 2>/dev/null`.split[1].to_i
+    end
+
+    def self.dynamic_width_tput
+      `tput cols 2>/dev/null`.to_i
+    end
+
+    def self.unix?
+      RUBY_PLATFORM =~
+        /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
+    end
+  end
+end


### PR DESCRIPTION
This allows users specify the width which is useful on non unix systems or when
they would like to override the default behaviour.

Here is a screenshot which demonstrates the change and also updated cli help.
<img width="852" alt="Screenshot 2020-04-18 at 19 04 34" src="https://user-images.githubusercontent.com/578608/79647187-1250de80-81a8-11ea-8cdc-36b04a97194e.png">
The screenshot also shows that for some reason when the default computed width is used (117) 
the report is not displayed correctly. So having ability to override the width handy.
