### PR TITLE
Always enable track when tracking query within a block

### DIFF
--- a/lib/sql_tracker.rb
+++ b/lib/sql_tracker.rb
@@ -15,7 +15,8 @@ module SqlTracker
   end
 
   def self.track
-    config = SqlTracker::Config.apply_defaults
+    config = SqlTracker::Config.apply_defaults.new
+    config.enabled = true
     handler = SqlTracker::Handler.new(config)
     handler.subscribe
     yield

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 module SqlTracker
   class ConfigTest < Minitest::Test
+    def setup
+      reset_sql_tracker_options
+    end
+
     def test_defaults_should_not_overwrite_user_configs
       SqlTracker::Config.enabled = false
       SqlTracker::Config.tracked_paths = %w(app/model)

--- a/test/handler_test.rb
+++ b/test/handler_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 module SqlTracker
   class HandlerTest < Minitest::Test
+    def setup
+      reset_sql_tracker_options
+    end
+    
     def test_should_track_sql_command_in_the_list
       config = sample_config
       config.tracked_sql_command = %w(SELECT)

--- a/test/handler_test.rb
+++ b/test/handler_test.rb
@@ -171,7 +171,7 @@ module SqlTracker
     private
 
     def sample_config
-      config = SqlTracker::Config.apply_defaults
+      config = SqlTracker::Config.apply_defaults.new
       config.enabled = true
       config
     end

--- a/test/sql_tracker_test.rb
+++ b/test/sql_tracker_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 module SqlTracker
   class HandlerTest < Minitest::Test
+    def setup
+      reset_sql_tracker_options
+    end
+
     def test_tracking_queries_with_a_block
       SqlTracker::Config.tracked_sql_command = %w(SELECT INSERT)
 

--- a/test/sql_tracker_test.rb
+++ b/test/sql_tracker_test.rb
@@ -3,9 +3,7 @@ require 'test_helper'
 module SqlTracker
   class HandlerTest < Minitest::Test
     def test_tracking_queries_with_a_block
-      config = SqlTracker::Config.apply_defaults
-      config.enabled = true
-      config.tracked_sql_command = %w(SELECT INSERT)
+      SqlTracker::Config.tracked_sql_command = %w(SELECT INSERT)
 
       expected_queries = [
         'SELECT * FROM users',
@@ -23,6 +21,16 @@ module SqlTracker
         expected_queries,
         query_data.values.map { |v| v[:sql] }
       )
+    end
+
+    def test_track_is_always_enabled_when_using_a_block
+      SqlTracker::Config.enabled = false
+      query = 'SELECT * FROM users'
+      query_data = SqlTracker.track do
+        instrument_query(query)
+      end
+      refute_empty(query_data)
+      assert_equal(query, query_data.values.first[:sql])
     end
 
     private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,10 @@ require 'active_support'
 require 'active_support/core_ext/string'
 
 require 'minitest/autorun'
+
+def reset_sql_tracker_options
+  SqlTracker::Config.enabled = nil
+  SqlTracker::Config.tracked_paths = nil
+  SqlTracker::Config.tracked_sql_command = nil
+  SqlTracker::Config.output_path = nil
+end


### PR DESCRIPTION
With this change, the setting: `SqlTracker::Config.enabled = true/false` will not take into effect when you use the track with block style:
```ruby
SqlTracker.track do
  # Run some active record queries
end
```
The `SqlTracker::Config.enabled` setting is used to control whether or not to track queries while Rails instance is running, and then with this setting set to `true`, it would save the data to a file after the instance stops.

fixes #9 